### PR TITLE
pymunk pygame vertical flip problem

### DIFF
--- a/docs/intro/intro.py
+++ b/docs/intro/intro.py
@@ -11,6 +11,7 @@ class App:
     size = 700, 240
     def __init__(self):
         pygame.init()
+        pymunk.pygame_util.positive_y_is_up = True
         self.screen = pygame.display.set_mode(self.size)
         self.draw_options = pymunk.pygame_util.DrawOptions(self.screen)
         self.running = True


### PR DESCRIPTION
Including the following line ensures that the problem created due to the y = 0 being at the top of the screen in pygame is solved. 
`pymunk.pygame_util.positive_y_is_up = True`

Not including it will give the vertically flipped version of the pymunk.space on the pygame screen render
